### PR TITLE
feature: add dispatch to docker repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,9 +132,9 @@ jobs:
       - name: Install dependencies
         run: go mod download
       - name: Build application
-        run: go build -v ./...
+        run: CGO_ENABLED=0 go build
       - name: Test application
-        run: go test -v ./...
+        run: go test
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,8 @@ jobs:
     name: go-release
     runs-on: ubuntu-latest
     needs: build
+    outputs:
+      version: ${{ steps.get-version.outputs.VERSION }}
     env:
       EXECUTABLE: bin/pca-linux-amd64/pca-linux-amd64
     steps:
@@ -119,35 +121,21 @@ jobs:
                 "${UPLOAD_URL}?name=$(basename ${FILE})";
             done
           done
-      - name: Create VERSION.txt
+      - id: get-version
+        name: Output application version
         run: |
-          echo "$VERSION" > VERSION.txt
-      - name: Upload to artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: version
-          path: VERSION.txt
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
   dispatch:
     needs: release
     runs-on: ubuntu-latest
     steps:
-      - name: Download version
-        uses: actions/download-artifact@v3
-        with:
-          name: version
-      - name: Get Version
-        run: |
-          echo "VERSION=$(cat VERSION.txt)" >> $GITHUB_ENV
-      - name: Get branch name
-        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
-        id: ref
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.CON_PCA_ACCESS_TOKEN }}
           repository: cisagov/con-pca-tasks-docker
           event-type: deploy
-          client-payload: '{"version": "${{ env.VERSION }}" }'
+          client-payload: '{"version": "${{ needs.release.outputs.version }}" }'
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: release
 
 on:
   push:
-    # branches:
-    #   - develop
+    branches:
+      - develop
 
 env:
   RUN_TMATE: ${{ secrets.RUN_TMATE }}
@@ -52,7 +52,7 @@ jobs:
           restore-keys: |
             ${{ env.BASE_CACHE_KEY }}
       - name: Build ${{ matrix.bin }}
-        run: go build -o ${{ matrix.bin }}
+        run: CGO_ENABLED=0 go build -o ${{ matrix.bin }}
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.arch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: release
 
 on:
   push:
-    branches:
-      - develop
+    # branches:
+    # - develop
 
 env:
   RUN_TMATE: ${{ secrets.RUN_TMATE }}
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     outputs:
-      version: ${{ steps.get-version.outputs.VERSION }}
+      version: ${{ steps.get-version.outputs.version }}
     env:
       EXECUTABLE: bin/pca-linux-amd64/pca-linux-amd64
     steps:
@@ -77,10 +77,11 @@ jobs:
           path: bin
       - name: Make retrieved artifact executable
         run: chmod +x ./${{ env.EXECUTABLE }}
-      - name: Set Tag Version
+      - id: get-version
+        name: Set Tag Version
         run: |
-          echo "VERSION=$($EXECUTABLE -version)" \
-          >> $GITHUB_ENV
+          echo "version=$($EXECUTABLE -version)" \
+          >> $GITHUB_OUTPUT
       - name: Create Release
         uses: actions/github-script@v6
         with:
@@ -94,7 +95,7 @@ jobs:
                 owner: context.repo.owner,
                 prerelease: false,
                 repo: context.repo.repo,
-                tag_name: `v${process.env.VERSION}`,
+                tag_name: `v${{ steps.get-version.outputs.version }}`,
               });
               core.exportVariable('RELEASE_ID', response.data.id);
               core.exportVariable('RELEASE_UPLOAD_URL', response.data.upload_url);
@@ -121,10 +122,6 @@ jobs:
                 "${UPLOAD_URL}?name=$(basename ${FILE})";
             done
           done
-      - id: get-version
-        name: Output application version
-        run: |
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
   dispatch:
     needs: release
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: release
 
 on:
   push:
-    # branches:
-    # - develop
+    branches:
+      - develop
 
 env:
   RUN_TMATE: ${{ secrets.RUN_TMATE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,3 +125,18 @@ jobs:
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get branch name
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+        id: ref
+      - name: Echo branch
+        run: echo "${{ steps.ref.outputs.branch }}"
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.CON_PCA_ACCESS_TOKEN }}
+          repository: cisagov/con-pca-tasks-docker
+          event-type: deploy-tasks
+          client-payload: '{"version": ${$VERSION}}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: release
 
 on:
   push:
-    # branches:
-    #   - develop
+    branches:
+      - develop
 
 env:
   RUN_TMATE: ${{ secrets.RUN_TMATE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: release
 
 on:
   push:
-    branches:
-      - develop
+    # branches:
+    #   - develop
 
 env:
   RUN_TMATE: ${{ secrets.RUN_TMATE }}
@@ -78,7 +78,7 @@ jobs:
       - name: Make retrieved artifact executable
         run: chmod +x ./${{ env.EXECUTABLE }}
       - id: get-version
-        name: Set Tag Version
+        name: Get the con-pca-tasks Version
         run: |
           echo "version=$($EXECUTABLE -version)" \
           >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
         run: chmod +x ./${{ env.EXECUTABLE }}
       - name: Set Tag Version
         run: |
-          echo "VERSION=v$($EXECUTABLE -version)" \
+          echo "VERSION=$($EXECUTABLE -version)" \
           >> $GITHUB_ENV
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3
@@ -91,11 +91,11 @@ jobs:
               const response = await github.rest.repos.createRelease({
                 draft: false,
                 generate_release_notes: true,
-                name: `con-pca-tasks ${process.env.VERSION}`,
+                name: `con-pca-tasks v${process.env.VERSION}`,
                 owner: context.repo.owner,
                 prerelease: false,
                 repo: context.repo.repo,
-                tag_name: process.env.VERSION,
+                tag_name: `v${process.env.VERSION}`,
               });
               core.exportVariable('RELEASE_ID', response.data.id);
               core.exportVariable('RELEASE_UPLOAD_URL', response.data.upload_url);
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get branch name
-        run: echo "branch=${GITHUB_REF#refs/heads/}"
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
         id: ref
       - name: Echo branch
         run: echo "${{ steps.ref.outputs.branch }}"
@@ -140,4 +140,4 @@ jobs:
           token: ${{ secrets.CON_PCA_ACCESS_TOKEN }}
           repository: cisagov/con-pca-tasks-docker
           event-type: deploy
-          client-payload: '{"version": $VERSION}'
+          client-payload: '{"version": "${{ env.VERSION }}" }'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,10 +129,10 @@ jobs:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ secrets.CON_PCA_ACCESS_TOKEN }}
-          repository: cisagov/con-pca-tasks-docker
-          event-type: deploy
           client-payload: '{"version": "${{ needs.release.outputs.version }}" }'
+          event-type: deploy
+          repository: cisagov/con-pca-tasks-docker
+          token: ${{ secrets.CON_PCA_ACCESS_TOKEN }}
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
               const response = await github.rest.repos.createRelease({
                 draft: false,
                 generate_release_notes: true,
-                name: `con-pca-tasks v${process.env.VERSION}`,
+                name: `con-pca-tasks v${{ steps.get-version.outputs.version }}`,
                 owner: context.repo.owner,
                 prerelease: false,
                 repo: context.repo.repo,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: release
 
 on:
   push:
-    # branches:
-    #   - develop
+    branches:
+      - develop
 
 env:
   RUN_TMATE: ${{ secrets.RUN_TMATE }}
@@ -79,9 +79,6 @@ jobs:
         run: |
           echo "VERSION=$($EXECUTABLE -version)" \
           >> $GITHUB_ENV
-      - name: Setup tmate debug session
-        uses: mxschmitt/action-tmate@v3
-        if: env.RUN_TMATE
       - name: Create Release
         uses: actions/github-script@v6
         with:
@@ -122,18 +119,28 @@ jobs:
                 "${UPLOAD_URL}?name=$(basename ${FILE})";
             done
           done
-      - name: Setup tmate debug session
-        uses: mxschmitt/action-tmate@v3
-        if: env.RUN_TMATE
+      - name: Create VERSION.txt
+        run: |
+          echo "$VERSION" > VERSION.txt
+      - name: Upload to artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: version
+          path: VERSION.txt
   dispatch:
     needs: release
     runs-on: ubuntu-latest
     steps:
+      - name: Download version
+        uses: actions/download-artifact@v3
+        with:
+          name: version
+      - name: Get Version
+        run: |
+          echo "VERSION=$(cat VERSION.txt)" >> $GITHUB_ENV
       - name: Get branch name
         run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
         id: ref
-      - name: Echo branch
-        run: echo "${{ steps.ref.outputs.branch }}"
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v2
         with:
@@ -141,3 +148,6 @@ jobs:
           repository: cisagov/con-pca-tasks-docker
           event-type: deploy
           client-payload: '{"version": "${{ env.VERSION }}" }'
+      - name: Setup tmate debug session
+        uses: mxschmitt/action-tmate@v3
+        if: env.RUN_TMATE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: release
 
 on:
   push:
-    branches:
-      - develop
+    # branches:
+    #   - develop
 
 env:
   RUN_TMATE: ${{ secrets.RUN_TMATE }}
@@ -126,10 +126,11 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
   dispatch:
+    needs: release
     runs-on: ubuntu-latest
     steps:
       - name: Get branch name
-        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+        run: echo "branch=${GITHUB_REF#refs/heads/}"
         id: ref
       - name: Echo branch
         run: echo "${{ steps.ref.outputs.branch }}"
@@ -138,5 +139,5 @@ jobs:
         with:
           token: ${{ secrets.CON_PCA_ACCESS_TOKEN }}
           repository: cisagov/con-pca-tasks-docker
-          event-type: deploy-tasks
-          client-payload: '{"version": ${$VERSION}}'
+          event-type: deploy
+          client-payload: '{"version": $VERSION}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: release
 
 on:
   push:
-    branches:
-      - develop
+    # branches:
+    #   - develop
 
 env:
   RUN_TMATE: ${{ secrets.RUN_TMATE }}


### PR DESCRIPTION
Add a dispatch step to trigger a build at `cisagov/con-pca-tasks-docker` repo

## 🗣 Description ##
Dispatch step depends on a release being completed.
Disabled CGO as it's not needed to run C libraries and allows for a performance boost.

## 💭 Motivation and context ##
Part of the effort to automate deployments

## 🧪 Testing ##
will be testing within this PR's gha checks

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
