### PR TITLE
fix init when calling version flag

### DIFF
--- a/initialize.go
+++ b/initialize.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	db "github.com/cisagov/con-pca-tasks/database"
+	"github.com/cisagov/con-pca-tasks/services/aws"
+)
+
+// Initialize the database and AWS clients
+func Init() {
+	// Connect to the database
+	db.InitDB()
+
+	// Initialize SES email
+	aws.SESEmailClient()
+}

--- a/main.go
+++ b/main.go
@@ -6,9 +6,7 @@ import (
 	"os"
 
 	"github.com/cisagov/con-pca-tasks/controllers"
-	db "github.com/cisagov/con-pca-tasks/database"
 	"github.com/cisagov/con-pca-tasks/notifications"
-	"github.com/cisagov/con-pca-tasks/services/aws"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -18,12 +16,6 @@ func init() {
 	// Load the API key from the environment
 	apiKey = os.Getenv("API_ACCESS_KEY")
 	notifications.ApiUrl = os.Getenv("API_URL")
-
-	// Connect to the database
-	db.InitDB()
-
-	// Initialize SES email
-	aws.SESEmailClient()
 }
 
 // Auth is a middleware that verifies the API key
@@ -42,6 +34,10 @@ func main() {
 	// Print the version and exit if the -version flag is provided
 	version()
 
+	// Initialize clients
+	Init()
+
+	// Create the router
 	r := chi.NewRouter()
 
 	// Protected routes


### PR DESCRIPTION
`-version` flag is failing due to db and aws clients initialized before hand

## 🗣 Description ##
initialize all clients only when `-version` flag is not called.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
tested locally

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
